### PR TITLE
no one should get to this contest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "files": [
     "src/**/*.{js,d.ts,d.ts.map,json}"
   ],

--- a/src/data/electionSample.json
+++ b/src/data/electionSample.json
@@ -681,7 +681,7 @@
     },
     {
       "id": "measure-666",
-      "districtId": "district-1",
+      "districtId": "district-666",
       "partyId": "2",
       "type": "yesno",
       "section": "Franklin County",


### PR DESCRIPTION
Contests are filtered by `districtId`. If this contest should not be included, then its `districtId` should not be included in the list of district ids for the `ballotStyle`.