### PR TITLE
test: add fuzz testing for `BitReader` and `BitWriter`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,9 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  testMatch: ['<rootDir>/{src,test}/**/*.test.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/expect.ts'],
-  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
+  collectCoverageFrom: ['{src,test}/**/*.ts', '!src/**/*.d.ts'],
   coverageThreshold: {
     global: {
       statements: 100,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",
+    "@types/random-js": "^1.0.31",
     "@types/text-encoding": "^0.0.35",
     "@typescript-eslint/eslint-plugin": "^2.3.1",
     "@typescript-eslint/parser": "^2.3.1",
@@ -51,6 +52,7 @@
     "jest": "^24.9.0",
     "lint-staged": "^9.3.0",
     "prettier": "^1.18.2",
+    "random-js": "^2.1.0",
     "sort-package-json": "^1.22.1",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.3"

--- a/test/fuzz.test.ts
+++ b/test/fuzz.test.ts
@@ -1,0 +1,260 @@
+/**
+ * This test file is a bit different from the others. It does fuzz testing of
+ * `BitReader` and `BitWriter` by ensuring that a random sequence of
+ * corresponding write and read actions yields the appropriate values.
+ */
+
+/* eslint-disable no-bitwise, @typescript-eslint/no-explicit-any */
+
+import { Random } from 'random-js'
+import { inspect } from 'util'
+import {
+  BitReader,
+  BitWriter,
+  CustomEncoding,
+  Uint8Index,
+  Uint8Size,
+} from '../src/bits'
+
+type Instance = InstanceType<new (...args: any) => any>
+
+interface Action<C extends Instance, M extends keyof C = keyof C> {
+  method: M
+  args: Parameters<C[M]>
+  returnValue?: ReturnType<C[M]>
+}
+
+interface PerformedAction<C extends Instance, M extends keyof C = keyof C>
+  extends Action<C, M> {
+  receiver: C
+}
+
+const random = new Random()
+
+type ActionsPairs = [Action<BitWriter>[], Action<BitReader>[]]
+
+const testCaseFactories = {
+  'vararg booleans': (): ActionsPairs => {
+    const argCount = random.integer(0, 10)
+    const args = new Array<boolean>(argCount)
+      .fill(false)
+      .map(() => random.bool())
+
+    return [
+      [{ method: 'writeBoolean', args }],
+      args.map(arg => ({
+        method: 'readBoolean',
+        args: [],
+        returnValue: arg,
+      })),
+    ]
+  },
+
+  'length-prefixed utf-8 strings': (): ActionsPairs => {
+    const length = random.integer(0, 50)
+    const maxLength = random.integer(length, length * 2)
+    const string = random.string(length)
+
+    return [
+      [{ method: 'writeString', args: [string, { maxLength }] }],
+      [{ method: 'readString', args: [{ maxLength }], returnValue: string }],
+    ]
+  },
+
+  'length-prefixed strings with custom encoding': (): ActionsPairs => {
+    const chars = Array.from(
+      new Set(random.string(random.integer(1, 20))).values()
+    ).join('')
+    const string = random.string(random.integer(0, 50), chars)
+    const encoding = new CustomEncoding(chars)
+
+    return [
+      [{ method: 'writeString', args: [string, { encoding }] }],
+      [{ method: 'readString', args: [{ encoding }], returnValue: string }],
+    ]
+  },
+
+  'dynamic size uints': (): ActionsPairs => {
+    const useMax = random.bool()
+    const useSize = !useMax
+    const max = useMax ? random.integer(0, 1 << 30) : undefined
+    const size = useSize ? random.integer(0, 30) : undefined
+    const number = random.integer(0, useMax ? max! : 1 << (size! - 1))
+
+    return [
+      [
+        {
+          method: 'writeUint',
+          args: [number, { max, size } as { size: number }] as Parameters<
+            BitWriter['writeUint']
+          >,
+        },
+      ],
+      [
+        {
+          method: 'readUint',
+          args: [{ max, size } as { size: number }] as Parameters<
+            BitReader['readUint']
+          >,
+          returnValue: number,
+        },
+      ],
+    ]
+  },
+
+  'vararg uint1s': (): ActionsPairs => {
+    const argCount = random.integer(0, 10)
+    const args = new Array<0 | 1>(argCount)
+      .fill(0)
+      .map(() => random.integer(0, 1))
+
+    return [
+      [
+        {
+          method: 'writeUint1',
+          args: args as Parameters<BitWriter['writeUint1']>,
+        },
+      ],
+      args.map(arg => ({
+        method: 'readUint1',
+        args: [],
+        returnValue: arg,
+      })),
+    ]
+  },
+
+  'vararg uint8s': (): ActionsPairs => {
+    const argCount = random.integer(0, 10)
+    const args = new Array<Uint8Index>(argCount)
+      .fill(0)
+      .map(() => random.integer(0, Uint8Size - 1))
+
+    return [
+      [
+        {
+          method: 'writeUint8',
+          args: args as Parameters<BitWriter['writeUint8']>,
+        },
+      ],
+      args.map(arg => ({
+        method: 'readUint8',
+        args: [],
+        returnValue: arg,
+      })),
+    ]
+  },
+}
+
+const testCaseNames = Object.getOwnPropertyNames(
+  testCaseFactories
+) as (keyof typeof testCaseFactories)[]
+
+function doWritesAndReads([writes, reads]: ActionsPairs): void {
+  const performedActions: PerformedAction<any>[] = []
+  const writer = new BitWriter()
+
+  for (const write of writes) {
+    performAction(write, writer, performedActions)
+  }
+
+  const reader = new BitReader(writer.toUint8Array())
+
+  for (const read of reads) {
+    performAction(read, reader, performedActions)
+  }
+}
+
+for (const testCase of testCaseNames) {
+  test(testCase, () => {
+    for (let i = 0; i < 1000; i += 1) {
+      doWritesAndReads(testCaseFactories[testCase]())
+    }
+  })
+}
+
+test('all together', () => {
+  for (let i = 0; i < 100; i += 1) {
+    const factories = new Array(20)
+      .fill(undefined)
+      .map(() => testCaseFactories[random.pick(testCaseNames)])
+
+    const [writes, reads]: ActionsPairs = [[], []]
+
+    for (const factory of factories) {
+      const [w, r] = factory()
+
+      writes.push(...w)
+      reads.push(...r)
+    }
+
+    doWritesAndReads([writes, reads])
+  }
+})
+
+const codeColor = '\x1b[38;5;202m'
+const resetColor = '\x1b[0m'
+
+function formatAction<C extends Instance>(
+  action: Action<C>,
+  instance: C,
+  includeReturnValue = false
+): string {
+  return `${codeColor}${instance.constructor.name}#${
+    action.method
+  }(${resetColor}${action.args
+    .map(arg => inspect(arg, { colors: true }))
+    .join(', ')}${codeColor})${resetColor}${
+    includeReturnValue && typeof action.returnValue !== 'undefined'
+      ? ` → ${inspect(action.returnValue, { colors: true })}`
+      : ''
+  }`
+}
+
+function formatActions<C extends Instance>(
+  actions: PerformedAction<C>[]
+): string {
+  if (actions.length === 0) {
+    return '- \x1b[38;5;240mn/a\x1b[0m'
+  }
+
+  return actions
+    .map(action => `- ${formatAction(action, action.receiver, true)}`)
+    .join('\n')
+}
+
+function performAction<C extends Instance>(
+  action: Action<C>,
+  instance: C,
+  performedActions: PerformedAction<C>[]
+): void {
+  let actualValue: typeof action['returnValue']
+
+  try {
+    actualValue = instance[action.method](...action.args)
+  } catch (error) {
+    error.message = `After performing these actions:\n${formatActions(
+      performedActions
+    )}\n\nAction ${formatAction(action, instance)}${
+      typeof action.returnValue === 'undefined'
+        ? ''
+        : ` (expected return ${inspect(action.returnValue, { colors: true })})`
+    } failed with error message: ${error.message}`
+    throw error
+  }
+
+  if (typeof action.returnValue !== 'undefined') {
+    try {
+      expect(actualValue).toEqual(action.returnValue)
+    } catch (error) {
+      error.message = `After performing these actions:\n${formatActions(
+        performedActions
+      )}\n\nAction ${formatAction(
+        action,
+        instance
+      )} did not match expected value.\n\n${error.message}`
+      throw error
+    }
+  }
+
+  performedActions.push({ ...action, receiver: instance })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/random-js@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/random-js/-/random-js-1.0.31.tgz#18a8bcc075afa504421e638fcbe021f27e802941"
+  integrity sha512-EAM56DrKw3VhcE4HV0/YlVKeJI07We4Mz1ra6TNtZpaMoiBVMA2bkLEcoFpYOyxoDXfVZWojxkR617LTqtRI0A==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -3861,6 +3866,11 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+random-js@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-2.1.0.tgz#0c03238b0a4f701f7a4c7303036ade3083d8ee14"
+  integrity sha512-CRUyWmnzmZBA7RZSVGq0xMqmgCyPPxbiKNLFA5ud7KenojVX2s7Gv+V7eB52beKTPGxWRnVZ7D/tCIgYJJ8vNQ==
 
 rc@^1.2.7:
   version "1.2.8"


### PR DESCRIPTION
Something I wanted to do when I was writing these initially, just to ensure a high degree of confidence in these basic classes.

Here's an example of a failure:

<img width="628" alt="image" src="https://user-images.githubusercontent.com/1938/66097461-57d2f480-e553-11e9-92b4-9496ad08f0e8.png">

And the diff that caused it:

```diff
diff --git a/src/bits/BitReader.ts b/src/bits/BitReader.ts
index ec24f65..95070c4 100644
--- a/src/bits/BitReader.ts
+++ b/src/bits/BitReader.ts
@@ -73,7 +73,7 @@ export default class BitReader {
     }
 
     // Fall back to reading bits individually.
-    let result = 0
+    let result = 1
 
     for (const mask of makeMasks(sizeofUint)) {
       const bit = this.readUint1()
```