### PR TITLE
fix: check election definition for semantic errors

### DIFF
--- a/src/election.ts
+++ b/src/election.ts
@@ -385,6 +385,154 @@ function copyWithLocale<T>(value: T, locale: string): T {
 }
 
 // Parsing
+export class ElectionParseError extends Error {
+  public constructor(public readonly errors: ElectionDefinitionError[]) {
+    super(errors.map(({ message }) => message).join('\n'))
+  }
+}
+
 export function parseElection(object: unknown): Election {
-  return s.Election.parse(object)
+  const election = s.Election.parse(object)
+  const errors = [...findElectionDefinitionErrors(election)]
+
+  if (errors.length) {
+    throw new ElectionParseError(errors)
+  }
+
+  return election
+}
+
+export type ElectionDefinitionError = InvalidReference | DuplicateIdentifier
+
+export interface InvalidReference {
+  type: 'InvalidReference'
+  source: string
+  reference: string
+  message: string
+}
+
+export interface DuplicateIdentifier {
+  type: 'DuplicateIdentifier'
+  message: string
+}
+
+export function* findElectionDefinitionErrors(
+  election: Election
+): Generator<ElectionDefinitionError> {
+  for (const { id, districts, precincts } of election.ballotStyles) {
+    for (const [districtIndex, districtId] of districts.entries()) {
+      if (!election.districts.some(({ id }) => id === districtId)) {
+        yield {
+          type: 'InvalidReference',
+          source: `ballotStyles[id=${id}].districts[${districtIndex}]`,
+          reference: `districts[id=${districtId}]`,
+          message: `Ballot style '${id}' has district '${districtId}', but no such district is defined. Districts defined: [${election.districts
+            .map(({ id }) => id)
+            .join(', ')}].`,
+        }
+      }
+    }
+
+    for (const [precinctIndex, precinctId] of precincts.entries()) {
+      if (!election.precincts.some(({ id }) => id === precinctId)) {
+        yield {
+          type: 'InvalidReference',
+          source: `ballotStyles[id=${id}].precincts[${precinctIndex}]`,
+          reference: `districts[id=${precinctId}]`,
+          message: `Ballot style '${id}' has precinct '${precinctId}', but no such precinct is defined. Precincts defined: [${election.precincts
+            .map(({ id }) => id)
+            .join(', ')}].`,
+        }
+      }
+    }
+  }
+
+  for (const contest of election.contests) {
+    if (contest.type === 'candidate') {
+      if (
+        contest.partyId &&
+        !election.parties.some(({ id }) => id === contest.partyId)
+      ) {
+        yield {
+          type: 'InvalidReference',
+          source: `contests[id=${contest.id}].partyId`,
+          reference: `parties[id=${contest.partyId}]`,
+          message: `Contest '${contest.id}' has party '${
+            contest.partyId
+          }', but no such party is defined. Parties defined: [${election.parties
+            .map(({ id }) => id)
+            .join(', ')}].`,
+        }
+      }
+
+      for (const candidate of contest.candidates) {
+        if (
+          candidate.partyId &&
+          !election.parties.some(({ id }) => id === candidate.partyId)
+        ) {
+          yield {
+            type: 'InvalidReference',
+            source: `contests[id=${contest.id}].candidates[id=${candidate.id}].partyId`,
+            reference: `parties[id=${candidate.partyId}]`,
+            message: `Candidate '${candidate.id}' in contest '${
+              contest.id
+            }' has party '${
+              candidate.partyId
+            }', but no such party is defined. Parties defined: [${election.parties
+              .map(({ id }) => id)
+              .join(', ')}].`,
+          }
+        }
+      }
+
+      for (const id of findDuplicateIds(contest.candidates)) {
+        yield {
+          type: 'DuplicateIdentifier',
+          message: `Duplicate candidate '${id}' found in contest '${contest.id}'.`,
+        }
+      }
+    }
+  }
+
+  for (const id of findDuplicateIds(election.districts)) {
+    yield {
+      type: 'DuplicateIdentifier',
+      message: `Duplicate district '${id}' found.`,
+    }
+  }
+
+  for (const id of findDuplicateIds(election.precincts)) {
+    yield {
+      type: 'DuplicateIdentifier',
+      message: `Duplicate precinct '${id}' found.`,
+    }
+  }
+
+  for (const id of findDuplicateIds(election.contests)) {
+    yield {
+      type: 'DuplicateIdentifier',
+      message: `Duplicate contest '${id}' found.`,
+    }
+  }
+
+  for (const id of findDuplicateIds(election.parties)) {
+    yield {
+      type: 'DuplicateIdentifier',
+      message: `Duplicate party '${id}' found.`,
+    }
+  }
+}
+
+function* findDuplicateIds<Id, T extends { id: Id }>(
+  identifiables: Iterable<T>
+): Generator<Id> {
+  const knownIds = new Set<Id>()
+
+  for (const { id } of identifiables) {
+    if (knownIds.has(id)) {
+      yield id
+    } else {
+      knownIds.add(id)
+    }
+  }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -11,9 +11,9 @@ export const Translations = z.record(z.record(z.string()))
 // Candidates
 export const Candidate = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  name: z.string(),
-  partyId: z.string().optional(),
+  id: z.string().nonempty(),
+  name: z.string().nonempty(),
+  partyId: z.string().nonempty().optional(),
   isWriteIn: z.boolean().optional(),
 })
 
@@ -27,11 +27,11 @@ export const ContestTypes = z.union([
 
 export const Contest = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  districtId: z.string(),
-  partyId: z.string().optional(),
-  section: z.string(),
-  title: z.string(),
+  id: z.string().nonempty(),
+  districtId: z.string().nonempty(),
+  partyId: z.string().nonempty().optional(),
+  section: z.string().nonempty(),
+  title: z.string().nonempty(),
   type: ContestTypes,
 })
 
@@ -47,8 +47,8 @@ export const CandidateContest = Contest.merge(
 export const YesNoContest = Contest.merge(
   z.object({
     type: z.literal('yesno'),
-    description: z.string(),
-    shortTitle: z.string().optional(),
+    description: z.string().nonempty(),
+    shortTitle: z.string().nonempty().optional(),
   })
 )
 
@@ -57,38 +57,38 @@ export const Contests = z.array(z.union([CandidateContest, YesNoContest]))
 // Election
 export const BallotStyle = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  precincts: z.array(z.string()),
-  districts: z.array(z.string()),
-  partyId: z.string().optional(),
+  id: z.string().nonempty(),
+  precincts: z.array(z.string().nonempty()),
+  districts: z.array(z.string().nonempty()),
+  partyId: z.string().nonempty().optional(),
 })
 
 export const Party = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  name: z.string(),
-  fullName: z.string(),
-  abbrev: z.string(),
+  id: z.string().nonempty(),
+  name: z.string().nonempty(),
+  fullName: z.string().nonempty(),
+  abbrev: z.string().nonempty(),
 })
 
 export const Parties = z.array(Party)
 
 export const Precinct = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  name: z.string(),
+  id: z.string().nonempty(),
+  name: z.string().nonempty(),
 })
 
 export const District = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  name: z.string(),
+  id: z.string().nonempty(),
+  name: z.string().nonempty(),
 })
 
 export const County = z.object({
   _lang: Translations.optional(),
-  id: z.string(),
-  name: z.string(),
+  id: z.string().nonempty(),
+  name: z.string().nonempty(),
 })
 
 export const Election = z.object({
@@ -100,11 +100,11 @@ export const Election = z.object({
   districts: z.array(District),
   contests: Contests,
   date: z.string().refine(check8601, 'dates must be ISO 8601-formatted'),
-  seal: z.string().optional(),
-  sealURL: z.string().optional(),
+  seal: z.string().nonempty().optional(),
+  sealURL: z.string().nonempty().optional(),
   ballotStrings: z.record(z.union([z.string(), Translations])).optional(),
-  state: z.string(),
-  title: z.string(),
+  state: z.string().nonempty(),
+  title: z.string().nonempty(),
 })
 
 export const OptionalElection = Election.optional()


### PR DESCRIPTION
Previous checks were just for structure and data type. This adds checks for invalid reference and duplicate identifiers.