### PR TITLE
feat: add some election settings to Election

### DIFF
--- a/src/election.ts
+++ b/src/election.ts
@@ -86,6 +86,8 @@ export interface Election {
   readonly ballotStrings?: BallotStrings
   readonly state: string
   readonly title: string
+  readonly markThresholds?: MarkThresholds
+  readonly adjudicationReasons?: readonly AdjudicationReason[]
 }
 export type OptionalElection = Optional<Election>
 
@@ -101,6 +103,20 @@ export enum BallotType {
   Standard = 0,
   Absentee = 1,
   Provisional = 2,
+}
+
+// Hand-marked paper & adjudication
+export interface MarkThresholds {
+  readonly marginal: number
+  readonly definite: number
+}
+
+export enum AdjudicationReason {
+  UninterpretableBallot = 'UninterpretableBallot',
+  MarginalMark = 'MarginalMark',
+  Overvote = 'Overvote',
+  Undervote = 'Undervote',
+  WriteIn = 'WriteIn',
 }
 
 // Updating this value is a breaking change.

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -1,4 +1,4 @@
-import { parseElection, electionSample } from './election'
+import { parseElection, electionSample, AdjudicationReason } from './election'
 
 test('parsing a valid election', () => {
   expect(parseElection(electionSample)).toEqual(electionSample)
@@ -18,4 +18,80 @@ test('contest IDs cannot start with an underscore', () => {
       })
     )
   ).toThrowError('IDs may not start with an underscore')
+})
+
+test('allows valid mark thresholds', () => {
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      markThresholds: { definite: 0.2, marginal: 0.2 },
+    })
+  ).not.toThrowError()
+
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      markThresholds: { definite: 0.2, marginal: 0.1 },
+    })
+  ).not.toThrowError()
+})
+
+test('disallows invalid mark thresholds', () => {
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      markThresholds: { definite: 0.2, marginal: 0.3 },
+    })
+  ).toThrowError(
+    'marginal mark threshold must be less than or equal to definite mark threshold'
+  )
+
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      markThresholds: { marginal: 0.3 },
+    })
+  ).toThrowError('definite: Non-number type: undefined')
+
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      markThresholds: { definite: 1.2, marginal: 0.3 },
+    })
+  ).toThrowError('definite: Value must be <= 1')
+})
+
+test('allows valid adjudication reasons', () => {
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      adjudicationReasons: [],
+    })
+  ).not.toThrowError()
+
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      adjudicationReasons: [
+        AdjudicationReason.MarginalMark,
+        AdjudicationReason.UninterpretableBallot,
+      ],
+    })
+  ).not.toThrowError()
+})
+
+test('disallows invalid adjudication reasons', () => {
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      adjudicationReasons: ['abcdefg'],
+    })
+  ).toThrowError('"abcdefg" does not match any value in enum')
+
+  expect(() =>
+    parseElection({
+      ...electionSample,
+      adjudicationReasons: 'foooo',
+    })
+  ).toThrowError('Non-array type: string')
 })


### PR DESCRIPTION
Adds `markThresholds`, which defines the score thresholds for considering a mark as either marginal or definite. Also adds `adjudicationReasons`, which describes which adjudication reasons should be considered as actually requiring adjudication. If either of these is absent, the default values will be used.