### PR TITLE
feat: add blank ballot adjudication reason

### DIFF
--- a/src/election.ts
+++ b/src/election.ts
@@ -117,6 +117,7 @@ export enum AdjudicationReason {
   Overvote = 'Overvote',
   Undervote = 'Undervote',
   WriteIn = 'WriteIn',
+  BlankBallot = 'BlankBallot',
 }
 
 // Updating this value is a breaking change.


### PR DESCRIPTION
I think this is different from just undervotes. This is a reason where _all_ contests have _no_ votes.