### PR TITLE
fix: allow reading the HMPB check data separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Optionally, deprecate a previous version. For example:
 
 ```ts
 import {
+  CompletedBallot,
   decodeBallot,
   electionSample as election,
   encodeBallot,
@@ -57,8 +58,7 @@ const votes = vote(contests, {
   'measure-101': 'no',
   '102': 'yes',
 })
-const ballot = {
-  election,
+const ballot: CompletedBallot = {
   ballotId,
   ballotStyle,
   precinct,
@@ -91,10 +91,10 @@ console.log(decodeBallot(election, encodeBallot(ballot)).ballot.votes)
 
 ## Usage
 
-To encode a ballot, simply pass a completed ballot object to `encodeBallot`.
-You'll get back a buffer that may be stored or transmitted and later passed to
-`decodeBallot` with the same `election` data that was part of the completed
-ballot object.
+To encode a ballot, simply pass an election and a completed ballot object to
+`encodeBallot`. You'll get back a buffer that may be stored or transmitted and
+later passed to `decodeBallot` with the same `election` data given to
+`encodeBallot`.
 
 There are multiple encoder versions and by default the latest will be used when
 encoding. To specify the version, pass the `EncoderVersion` as the second

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/ballot-encoder",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "files": [
     "src/**/*.{js,d.ts,d.ts.map,json}"
   ],

--- a/src/election.ts
+++ b/src/election.ts
@@ -152,12 +152,11 @@ export enum AdjudicationReason {
 export const BallotTypeMaximumValue = (1 << 4) - 1
 
 export interface CompletedBallot {
-  election: Election
   ballotStyle: BallotStyle
   precinct: Precinct
   ballotId: string
   votes: VotesDict
-  isTestBallot: boolean
+  isTestMode: boolean
   ballotType: BallotType
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,17 +25,16 @@ test('encodes with v1 by default', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(detect(encodeBallot(ballot))).toEqual(EncoderVersion.v1)
+  expect(detect(encodeBallot(election, ballot))).toEqual(EncoderVersion.v1)
 })
 
 test('can encode by version number', () => {
@@ -44,28 +43,27 @@ test('can encode by version number', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(encodeBallot(ballot, EncoderVersion.v0)).toEqual(
-    v0.encodeBallot(ballot)
+  expect(encodeBallot(election, ballot, EncoderVersion.v0)).toEqual(
+    v0.encodeBallot(election, ballot)
   )
 
-  expect(encodeBallot(ballot, EncoderVersion.v1)).toEqual(
-    v1.encodeBallot(ballot)
+  expect(encodeBallot(election, ballot, EncoderVersion.v1)).toEqual(
+    v1.encodeBallot(election, ballot)
   )
 })
 
 test('encoding with an invalid encoder version is an error', () => {
   expect(() =>
-    encodeBallot({} as CompletedBallot, 99 as EncoderVersion)
+    encodeBallot(election, {} as CompletedBallot, 99 as EncoderVersion)
   ).toThrowError('unexpected encoder version: 99')
 })
 
@@ -75,18 +73,17 @@ test('can decode specifying v0', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
   expect(
-    decodeBallot(election, v0.encodeBallot(ballot), EncoderVersion.v0)
+    decodeBallot(election, v0.encodeBallot(election, ballot), EncoderVersion.v0)
   ).toEqual({
     version: EncoderVersion.v0,
     ballot,
@@ -99,18 +96,17 @@ test('can decode specifying v1', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
   expect(
-    decodeBallot(election, v1.encodeBallot(ballot), EncoderVersion.v1)
+    decodeBallot(election, v1.encodeBallot(election, ballot), EncoderVersion.v1)
   ).toEqual({ version: EncoderVersion.v1, ballot })
 })
 
@@ -120,21 +116,20 @@ test('can decode and automatically detect the right version', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(decodeBallot(election, v0.encodeBallot(ballot))).toEqual({
+  expect(decodeBallot(election, v0.encodeBallot(election, ballot))).toEqual({
     version: EncoderVersion.v0,
     ballot,
   })
-  expect(decodeBallot(election, v1.encodeBallot(ballot))).toEqual({
+  expect(decodeBallot(election, v1.encodeBallot(election, ballot))).toEqual({
     version: EncoderVersion.v1,
     ballot,
   })
@@ -152,15 +147,14 @@ test('can detect v0 encoding', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(detect(v0.encodeBallot(ballot))).toEqual(EncoderVersion.v0)
+  expect(detect(v0.encodeBallot(election, ballot))).toEqual(EncoderVersion.v0)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,15 +14,16 @@ export enum EncoderVersion {
  * Encodes a ballot using the specified encoder version.
  */
 export function encodeBallot(
+  election: Election,
   ballot: CompletedBallot,
   version: EncoderVersion = EncoderVersion.v1
 ): Uint8Array {
   switch (version) {
     case EncoderVersion.v0:
-      return v0.encodeBallot(ballot)
+      return v0.encodeBallot(election, ballot)
 
     case EncoderVersion.v1:
-      return v1.encodeBallot(ballot)
+      return v1.encodeBallot(election, ballot)
 
     default:
       throw new Error(`unexpected encoder version: ${JSON.stringify(version)}`)

--- a/src/v0/index.test.ts
+++ b/src/v0/index.test.ts
@@ -4,6 +4,7 @@ import {
   electionSample as election,
   getContests,
   vote,
+  CompletedBallot,
 } from '../election'
 import * as v1 from '../v1'
 import {
@@ -34,17 +35,16 @@ test('does not detect a v1 buffer as v0', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(detect(v1.encodeBallot(ballot))).toBe(false)
+  expect(detect(v1.encodeBallot(election, ballot))).toBe(false)
 })
 
 test('does not detect if the check throws', () => {
@@ -67,17 +67,16 @@ test('encodes & decodes with Uint8Array as the standard encoding interface', () 
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(decodeBallot(election, encodeBallot(ballot))).toEqual(ballot)
+  expect(decodeBallot(election, encodeBallot(election, ballot))).toEqual(ballot)
 })
 
 test('encodes & decodes empty votes', () => {
@@ -86,18 +85,17 @@ test('encodes & decodes empty votes', () => {
   const contests = getContests({ election, ballotStyle })
   const votes = vote(contests, {})
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
   const encodedBallot = '12.23.|||||||||||||||||||.abcde'
 
-  expect(encodeBallotAsString(ballot)).toEqual(encodedBallot)
+  expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(decodeBallotFromString(election, encodedBallot)).toEqual(ballot)
 })
 
@@ -112,20 +110,22 @@ test('encodes & decodes yesno votes', () => {
     [yesnos[2].id]: [],
   })
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
   const encodedBallot = '12.23.||||||||||||1|0||||||.abcde'
 
-  expect(encodeBallotAsString(ballot)).toEqual(encodedBallot)
+  expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(
-    encodeBallotAsString(decodeBallotFromString(election, encodedBallot))
+    encodeBallotAsString(
+      election,
+      decodeBallotFromString(election, encodedBallot)
+    )
   ).toEqual(encodedBallot)
 })
 
@@ -140,18 +140,17 @@ test('encodes & decodes candidate votes', () => {
     [contest.id]: contest.candidates.slice(0, 2),
   })
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
   const encodedBallot = '12.23.0,1|||||||||||||||||||.abcde'
 
-  expect(encodeBallotAsString(ballot)).toEqual(encodedBallot)
+  expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(decodeBallotFromString(election, encodedBallot)).toEqual(ballot)
 })
 
@@ -168,18 +167,17 @@ test('encodes write-ins as `W`', () => {
     ],
   })
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
   const encodedBallot = '12.23.W|||||||||||||||||||.abcde'
 
-  expect(encodeBallotAsString(ballot)).toEqual(encodedBallot)
+  expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
 
   expect(decodeBallotFromString(election, encodedBallot)).toEqual({
     ...ballot,
@@ -195,7 +193,7 @@ test('encodes write-ins as `W`', () => {
       ],
     },
     // v0 does not encode whether a ballot is a test ballot
-    isTestBallot: false,
+    isTestMode: false,
     // v0 does not encode ballot type
     ballotType: BallotType.Standard,
   })
@@ -210,17 +208,16 @@ test('cannot encode a yesno contest with an invalid value', () => {
     [yesnos[0].id]: 'YEP',
   })
   const ballotId = 'abcde'
-  const ballot = {
-    election,
+  const ballot: CompletedBallot = {
     ballotId,
     ballotStyle,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 
-  expect(() => encodeBallot(ballot)).toThrowError(
+  expect(() => encodeBallot(election, ballot)).toThrowError(
     "cannot encode yesno vote, expected ['no'] or ['yes'] but got \"YEP\""
   )
 })

--- a/src/v0/index.ts
+++ b/src/v0/index.ts
@@ -57,20 +57,20 @@ export function detectString(data: string): boolean {
 /**
  * Encodes a ballot for transport or storage.
  */
-export function encodeBallot(ballot: CompletedBallot): Uint8Array {
-  return new TextEncoder().encode(encodeBallotAsString(ballot))
+export function encodeBallot(
+  election: Election,
+  ballot: CompletedBallot
+): Uint8Array {
+  return new TextEncoder().encode(encodeBallotAsString(election, ballot))
 }
 
 /**
  * Convenience function for encoding ballot data as a string, for testing.
  */
-export function encodeBallotAsString({
-  election,
-  ballotStyle,
-  precinct,
-  votes,
-  ballotId,
-}: CompletedBallot): string {
+export function encodeBallotAsString(
+  election: Election,
+  { ballotStyle, precinct, votes, ballotId }: CompletedBallot
+): string {
   const contests = getContests({ ballotStyle, election })
 
   return [
@@ -181,10 +181,9 @@ export function decodeBallotFromString(
   return {
     ballotId,
     ballotStyle,
-    election,
     precinct,
     votes,
-    isTestBallot: false,
+    isTestMode: false,
     ballotType: BallotType.Standard,
   }
 }

--- a/src/v1/index.test.ts
+++ b/src/v1/index.test.ts
@@ -594,7 +594,7 @@ test('encode and decode HMPB ballot page metadata', () => {
   const encoded = encodeHMPBBallotPageMetadata(ballotMetadata)
 
   expect(encoded).toEqual(
-    Uint8Array.from([
+    Uint8Array.of(
       86,
       80,
       1,
@@ -611,8 +611,8 @@ test('encode and decode HMPB ballot page metadata', () => {
       239,
       0,
       0,
-      224,
-    ])
+      224
+    )
   )
   const decoded = decodeHMPBBallotPageMetadata({ election, data: encoded })
   expect(decoded).toEqual(ballotMetadata)
@@ -645,7 +645,7 @@ test('encode and decode HMPB ballot page metadata with ballot ID', () => {
   const encoded = encodeHMPBBallotPageMetadata(ballotMetadata)
 
   expect(encoded).toEqual(
-    Uint8Array.from([
+    Uint8Array.of(
       86,
       80,
       1,
@@ -671,8 +671,8 @@ test('encode and decode HMPB ballot page metadata with ballot ID', () => {
       236,
       76,
       46,
-      64,
-    ])
+      64
+    )
   )
 
   const decoded = decodeHMPBBallotPageMetadata({ election, data: encoded })


### PR DESCRIPTION
This will allow us to validate the metadata before decoding the rest of it if we so desire.

Closes votingworks/vxmail#211