### PR TITLE
feat: add ms-either-neither to electionSample.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ yarn install
 yarn pnpify --sdk
 ```
 
+If packages are not resolving, ensure that VS Code is using the workspace
+version of TypeScript:
+
+1. Open any TypeScript file.
+2. Open command pallate with: Command-Shift-P
+3. Type `Select Typescript Version`
+4. Select `Use Workspace Version`
+
 ## Developing Alongside another Project
 
 In dev `ballot-encoder` dir, run `yarn tsc` to generate JavaScript files.

--- a/src/data/electionSample.json
+++ b/src/data/electionSample.json
@@ -830,6 +830,43 @@
       }
     },
     {
+      "id": "measure-420",
+      "districtId": "district-1",
+      "type": "ms-either-neither",
+      "section": "State of Hamilton",
+      "title": "Measure 420A/420B: Medical Marijuana Initiative",
+      "eitherNeitherContestId": "420A",
+      "pickOneContestId": "420B",
+      "description": "<strong>Measure 420A</strong>\n\n Description of Measure 420A here.\n\n<strong>Measure 420B</strong>\n\n Description of Measure 420B here.\n\n",
+      "eitherNeitherLabel": "Vote for either or against both",
+      "pickOneLabel": "Vote for your preferred option",
+      "eitherOption": {
+        "id": "420-either",
+        "label": "For either"
+      },
+      "neitherOption": {
+        "id": "420-neither",
+        "label": "Against both"
+      },
+      "firstOption": {
+        "id": "420A-option",
+        "label": "For Measure 420A"
+      },
+      "secondOption": {
+        "id": "420B-option",
+        "label": "For Measure 420B"
+      },
+      "_lang": {
+        "es-US": {
+          "section": "Estado de Hamilton",
+          "title": "Medida 420A/420B: Iniciativa de Marihuana Medicinal",
+          "description": "<strong>Medida 420A</strong>\n\n Descripción de la Medida 420A aquí.\n\n<strong>Medida 420B</strong>\n\n Descripción de la Medida 420B aquí.\n\n",
+          "eitherNeitherLabel": "Vota por uno o en contra de ambos",
+          "pickOneLabel": "Vote por su opción preferida"
+        }
+      }
+    },
+    {
       "id": "measure-101",
       "districtId": "district-2",
       "type": "yesno",

--- a/src/election.test.ts
+++ b/src/election.test.ts
@@ -195,7 +195,7 @@ test('parsing gives specific errors for nested objects', () => {
         },
       ],
     })
-  ).toThrowError(/contests.21:.*title: Non-string type: number/s)
+  ).toThrowError(/contests.22:.*title: Non-string type: number/s)
 })
 
 test('ensures dates are ISO 8601-formatted', () => {

--- a/src/v0/index.test.ts
+++ b/src/v0/index.test.ts
@@ -93,7 +93,7 @@ test('encodes & decodes empty votes', () => {
     isTestMode: false,
     ballotType: BallotType.Standard,
   }
-  const encodedBallot = '12.23.|||||||||||||||||||.abcde'
+  const encodedBallot = '12.23.||||||||||||||||||||.abcde'
 
   expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(decodeBallotFromString(election, encodedBallot)).toEqual(ballot)
@@ -118,7 +118,7 @@ test('encodes & decodes yesno votes', () => {
     isTestMode: false,
     ballotType: BallotType.Standard,
   }
-  const encodedBallot = '12.23.||||||||||||1|0||||||.abcde'
+  const encodedBallot = '12.23.||||||||||||1|0|||||||.abcde'
 
   expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(
@@ -148,7 +148,7 @@ test('encodes & decodes candidate votes', () => {
     isTestMode: false,
     ballotType: BallotType.Standard,
   }
-  const encodedBallot = '12.23.0,1|||||||||||||||||||.abcde'
+  const encodedBallot = '12.23.0,1||||||||||||||||||||.abcde'
 
   expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
   expect(decodeBallotFromString(election, encodedBallot)).toEqual(ballot)
@@ -175,7 +175,7 @@ test('encodes write-ins as `W`', () => {
     isTestMode: false,
     ballotType: BallotType.Standard,
   }
-  const encodedBallot = '12.23.W|||||||||||||||||||.abcde'
+  const encodedBallot = '12.23.W||||||||||||||||||||.abcde'
 
   expect(encodeBallotAsString(election, ballot)).toEqual(encodedBallot)
 
@@ -224,25 +224,25 @@ test('cannot encode a yesno contest with an invalid value', () => {
 
 test('cannot decode a ballot with a ballot style id that does not exist', () => {
   expect(() => {
-    decodeBallotFromString(election, '9999.23.|||||||||||||||||||.abcde')
+    decodeBallotFromString(election, '9999.23.||||||||||||||||||||.abcde')
   }).toThrowError('unable to find ballot style by id: 9999')
 })
 
 test('cannot decode a ballot with a precinct id that does not exist', () => {
   expect(() => {
-    decodeBallotFromString(election, '12.9999.|||||||||||||||||||.abcde')
+    decodeBallotFromString(election, '12.9999.||||||||||||||||||||.abcde')
   }).toThrowError('unable to find precinct by id: 9999')
 })
 
 test('cannot decode a ballot with an unexpected number of votes', () => {
   expect(() => {
     decodeBallotFromString(election, '12.23.|||.abcde')
-  }).toThrowError('found 4 vote(s), but expected 20 (one per contest)')
+  }).toThrowError('found 4 vote(s), but expected 21 (one per contest)')
 })
 
 test('cannot decode a yesno vote that is not "0" or "1"', () => {
   expect(() => {
-    decodeBallotFromString(election, '12.23.|||||||||||||W||||||.abcde')
+    decodeBallotFromString(election, '12.23.|||||||||||||W|||||||.abcde')
   }).toThrowError(
     'cannot decode yesno vote in contest "judicial-elmer-hull", expected "0" or "1" but got "W"'
   )
@@ -250,7 +250,7 @@ test('cannot decode a yesno vote that is not "0" or "1"', () => {
 
 test('cannot decode a ballot with a negative candidate index', () => {
   expect(() => {
-    decodeBallotFromString(election, '12.23.|-1||||||||||||||||||.abcde')
+    decodeBallotFromString(election, '12.23.|-1|||||||||||||||||||.abcde')
   }).toThrowError(
     'expected candidate index in contest "senator" to be in range [0, 7) but got "-1"'
   )
@@ -258,7 +258,7 @@ test('cannot decode a ballot with a negative candidate index', () => {
 
 test('cannot decode a ballot with a candidate index out of bounds', () => {
   expect(() => {
-    decodeBallotFromString(election, '12.23.|7||||||||||||||||||.abcde')
+    decodeBallotFromString(election, '12.23.|7|||||||||||||||||||.abcde')
   }).toThrowError(
     'expected candidate index in contest "senator" to be in range [0, 7) but got "7"'
   )
@@ -266,7 +266,7 @@ test('cannot decode a ballot with a candidate index out of bounds', () => {
 
 test('cannot decode a ballot that is missing a ballot id', () => {
   expect(() => {
-    decodeBallotFromString(election, '12.23.|||||||||||||||||||')
+    decodeBallotFromString(election, '12.23.||||||||||||||||||||')
   }).toThrowError(
     'ballot data is malformed, expected data in this format: «ballot style id».«precinct id».«encoded votes».«ballot id»'
   )


### PR DESCRIPTION
I wanted to add translations for the following but was unable to figure out how to do so without schema errors:
```
      "eitherOption": {
        "id": "420-either",
        "label": "For either",
        "_lang": {
          "es-US": {
            "label": "Ya sea para"
          }
        }
      },
      "neitherOption": {
        "id": "420-neither",
        "label": "Against both",
        "_lang": {
          "es-US": {
            "label": "Contra ambos"
          }
        }
      },
      "firstOption": {
        "id": "420A-option",
        "label": "For Measure 420A",
        "_lang": {
          "es-US": {
            "label": "Para Medida 420A"
          }
        }
      },
      "secondOption": {
        "id": "420B-option",
        "label": "For Measure 420B",
        "_lang": {
          "es-US": {
            "label": "Para Medida 420B"
          }
        }
      },
```

I tried the following but it didn't seem to make a difference: 
```diff
 export const YesNoOption = z.object({
+  _lang: Translations.optional(),
   id: Id,
   label: z.string().nonempty(),
 })
```